### PR TITLE
changed CDN server from retired cdn.mathjax.org to cdnjs.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   	}
 	});
 </script>
-	  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
+	  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 	  <!--<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG"></script>-->
 
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   	}
 	});
 </script>
-	  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+	  <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 	  <!--<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG"></script>-->
 
 


### PR DESCRIPTION
As asked from Linnea the CDN self hosted service from mathjax will be shut down, so I changed it to a mirror server which will still be available past April. The provider should be the same, so this little line change should do it.